### PR TITLE
feat: Properly add grammar changes for genzql 0.3.1.

### DIFF
--- a/zql/genzql/zql_grammar.tmjd
+++ b/zql/genzql/zql_grammar.tmjd
@@ -21,10 +21,10 @@ cte_list          : aliased_cte comma cte_list
                   > "{aliased_cte},\n{cte_list}"
                   | aliased_cte
                   ;
-aliased_cte       : word alias sub_query
-                  | open_paren expression close_paren alias word
-                  > "({expression}) {alias} {word}"
-                  | expression alias word
+aliased_cte       : alias_name alias sub_query
+                  | open_paren expression close_paren alias alias_name
+                  > "({expression}) {alias} {alias_name}"
+                  | expression alias alias_name
                   ;
 sub_query         : open_paren query close_paren 
                   > "{open_paren}\n{query}\n{close_paren}"
@@ -70,8 +70,8 @@ offset_query      : offset_clause union_query
                   | offset_clause
                   | union_query
                   ;
-union_query       : union_clause simple_query
-                  > "{union_clause}\n{simple_query}"
+union_query       : query_set_clause simple_query
+                  > "{query_set_clause}\n{simple_query}"
                   | terminal
                   ;
 select_clause     : select distinct select_expr_list
@@ -83,14 +83,14 @@ select_expr_list  : select_expr comma select_expr_list
                   > "\n  {select_expr}"
                   ;
 select_expr       : star
-                  | postfix_function alias word
-                  > "{postfix_function} {alias} {word}"
-                  | open_paren expression close_paren alias word
-                  > "{expression} {alias} {word}"
+                  | postfix_function alias alias_name
+                  > "{postfix_function} {alias} {alias_name}"
+                  | open_paren expression close_paren alias alias_name
+                  > "{expression} {alias} {alias_name}"
                   | open_paren expression close_paren
                   > "{expression}"
-                  | single_expr alias word
-                  | expression alias word
+                  | single_expr alias alias_name
+                  | expression alias alias_name
                   | postfix_function
                   | expression
                   | single_expr
@@ -189,12 +189,17 @@ integer           : @r[0-9]+
                   ;
 word              : @r[a-zA-Z][\w$]*
                   ;
-word1             : word
+dot_expression    : word_or_quoted dot dot_expression
+                  > "{word_or_quoted}.{dot_expression}"
+                  | word_or_quoted
                   ;
-word2             : word
+word_or_quoted    : word
+                  | quoted_expr
                   ;
-dot_expression    : word1 dot word2
-                  > "{word1}.{word2}"
+word_or_dotted    : dot_expression
+                  | word_or_quoted
+                  ;
+alias_name        : word_or_quoted
                   ;
 operator          : cond_operator
                   | comp_operator
@@ -225,15 +230,20 @@ math_operator     : plus
                   | divide
                   ;
 function_expr     : postfixable_fn
+                  | cast_fn
                   | function_name open_paren close_paren
                   > "{function_name}()"
                   | function_name open_paren function_args close_paren
                   > "{function_name}({function_args})"
                   ;
-function_args     : distinct arg_list
+function_args     : star
+                  | distinct arg_list
                   | arg_list
                   ;
 function_name     : word
+                  ;
+cast_fn           : cast open_paren expression alias alias_name close_paren
+                  > "{cast}({expression} {alias} {alias_name})"
                   ;
 arg_list          : expression comma arg_list
                   > "{expression}, {arg_list}"
@@ -250,15 +260,17 @@ from_clause       : from table join_list
                   > "{from} {table}\n{join_list}"
                   | from table
                   ;
-table             : sub_query alias word
+table             : sub_query alias alias_name
                   | sub_query non_keyword
                   | sub_query
                   | table_name
                   ;
-table_name        : word1 alias word2
-                  | word < sqlite
-                  | word non_keyword
-                  | word
+table_name        : word_or_dotted alias alias_name
+                  | word_or_dotted < sqlite
+                  | word_or_dotted non_keyword
+                  | word_or_dotted
+                  ;
+bare_table        : word_or_dotted
                   ;
 join_list         : join_clause join_list
                   > "{join_clause}\n{join_list}"
@@ -318,8 +330,13 @@ offset_clause     : offset offset_amount
                   ;
 offset_amount     : integer
                   ;
+query_set_clause  : union_clause
+                  | intersect_clause
+                  ;
 union_clause      : union_all
                   | union
+                  ;
+intersect_clause  : intersect
                   ;
 definition_stmt   : create_stmt
                   | drop_stmt
@@ -332,21 +349,21 @@ create_db_stmt    : create_db word if_not_exists
                   > "{create_db} {if_not_exists} {word}"
                   | create_db word
                   ;
-create_table_stmt : create_table db_table if_not_exists alias table_def
-                  > "{create_table} {if_not_exists} {db_table}{table_def}"
-                  | create_table db_table alias table_def
-                  > "{create_table} {db_table}{table_def}"
-                  | create_table db_table if_not_exists table_def
-                  > "{create_table} {if_not_exists} {db_table}{table_def}"
-                  | create_table db_table table_def
-                  > "{create_table} {db_table}{table_def}"
+create_table_stmt : create_table bare_table if_not_exists alias table_def
+                  > "{create_table} {if_not_exists} {bare_table}{table_def}"
+                  | create_table bare_table alias table_def
+                  > "{create_table} {bare_table}{table_def}"
+                  | create_table bare_table if_not_exists table_def
+                  > "{create_table} {if_not_exists} {bare_table}{table_def}"
+                  | create_table bare_table table_def
+                  > "{create_table} {bare_table}{table_def}"
                   ;
-describe_stmt     : pragma_describe open_paren db_table close_paren < sqlite
-                  > "{pragma_describe}({db_table})" < sqlite
-                  > "{pragma_describe} {db_table}"
-                  | pragma_describe db_table
-                  > "{pragma_describe}({db_table})" < sqlite
-                  > "{pragma_describe} {db_table}"
+describe_stmt     : pragma_describe open_paren bare_table close_paren < sqlite
+                  > "{pragma_describe}({bare_table})" < sqlite
+                  > "{pragma_describe} {bare_table}"
+                  | pragma_describe bare_table
+                  > "{pragma_describe}({bare_table})" < sqlite
+                  > "{pragma_describe} {bare_table}"
                   ;
 pragma_describe   : "PRAGMA table_info" < sqlite
                   > "PRAGMA table_info" < sqlite
@@ -430,16 +447,13 @@ drop_db_stmt      : drop_db word if_exists
                   > "{drop_db} {if_exists} {word}"
                   | drop_db word
                   ;
-drop_table_stmt   : drop_table db_table if_exists
-                  > "{drop_table} {if_exists} {db_table}"
-                  | drop_table db_table
-                  ;
-db_table          : word dot word
-                  | word
+drop_table_stmt   : drop_table bare_table if_exists
+                  > "{drop_table} {if_exists} {bare_table}"
+                  | drop_table bare_table
                   ;
 manipulation_stmt : insert_stmt
                   ;
-insert_stmt       : insert_into db_table insert_data
+insert_stmt       : insert_into bare_table insert_data
                   ;
 insert_data       : insert_keys values insert_vals
                   | values insert_vals
@@ -505,6 +519,13 @@ end               : "END" < sqlite
                   > "END" < sqlite
                   > "its chill"
                   ;
+cast              : "CAST" < sqlite
+                  > "CAST" < sqlite
+                  > "trust"
+                  | "trust"
+                  > "CAST" < sqlite
+                  > "trust"
+                  ;
 null              : "NULL" < sqlite
                   > "NULL" < sqlite
                   > "yikes"
@@ -529,11 +550,11 @@ join_on           : "ON" < sqlite
                   | "bet"
                   ;
 join_type         : join_inner
-                  | join_left
                   | join_left_outer
-                  | join_right
                   | join_right_outer
                   | join_full_outer
+                  | join_left
+                  | join_right
                   | join_cross
                   | join_array
                   ;
@@ -653,6 +674,9 @@ union_all         : "UNION ALL" < sqlite
                   ;
 union             : "UNION" < sqlite
                   | "with the bois"
+                  ;
+intersect         : "INTERSECT" < sqlite
+                  | "with the same bois"
                   ;
 explain           : "EXPLAIN" < sqlite
                   | "whats good with"


### PR DESCRIPTION
Note: Version 0.3.1 has not actually been published yet. This change just adds the new language features:

- `INTERSECTS` (`with the same bois`)
- `CAST(x AS type)` (`trust(x be type)`)
- Fix join type rule order so that outer joins of different types can be parsed
- Allow functions to take star `*` (`sheesh`) as their sole argument
- Allow aliases to be quoted names
- Allow table names to be dotted expressions
- Allow dotted expressions to contain quoted names
- Allow dotted expressions to have as many dot references as needed
- Allow table names in data definition and data manipulation statements to have as many dot references as needed